### PR TITLE
[BUG] fix: spread potentialPosts scores into Math.min() to fix weighted random selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1075,7 +1075,7 @@
         let bestPost = potentialPosts[0];
 
         if (Math.random() < 0.4) {
-            const minScore = Math.min(potentialPosts.map(e=>e.score));
+            const minScore = Math.min(...potentialPosts.map(e => e.score));
             const maxScore = potentialPosts.reduce((sum, post) => sum + post.score - minScore, 0);
             const targetScore = Math.random()*maxScore;
             let scoreCount = 0;


### PR DESCRIPTION
The 40% weighted-random branch in getNextPost() was silently broken, Math.min(array) returns NaN, causing the loop to never execute and falling back to an unweighted random pick.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/min

as this fix is pretty simple, I will not explain too much in detail. Cool project btw