### PR TITLE
Fix leaked reference URLs in parsed article text

### DIFF
--- a/process_data.py
+++ b/process_data.py
@@ -24,6 +24,7 @@ def process_page(xml):
     #text_toparse = re.sub('\\[\\[File:[^\\]]+\\]\\]\\n?', '', text_toparse)
     #text_toparse = re.sub('{{Infobox(?:[^{}]+(?:{{(?:[^{}]+(?:{{[^}]+}}|}))+}|}))+}', '', text_toparse, flags=re.MULTILINE)
     text_toparse = "\n".join(x for x in text_toparse.split("\n") if not x.startswith("thumb|") if not x.upper().startswith("__NOTOC__") and (len(x) == 0 or not x[0] in "{}[]|&<>-*= ")).strip("\n")
+    text_toparse = re.sub(r'<ref[^>]*>.*?</ref>', '', text_toparse, flags=re.DOTALL)
     text_toparse = "\n".join(text_toparse.split("\n\n")[0].split("\n")[:8])
     #print(f"< {title} >")
     parsed_text = mwparserfromhell.parse(text_toparse).strip_code().strip()


### PR DESCRIPTION
Fixes an issue where bare URLs inside `<ref>` tags could leak into parsed article text after `mwparserfromhell.strip_code()` processing.

This occurred with references containing inline bare URLs such as:

```wiki
<ref>https://example.com/ {{Bare URL inline}}</ref>
```

The fix removes `<ref>` blocks before parsing article text, preventing reference URLs from appearing in generated feed content.

Fixes #17
