### PR TITLE
fix reset algorithm clearing time statistics

### DIFF
--- a/index.html
+++ b/index.html
@@ -714,7 +714,7 @@
     }
 
     function resetAlgorithm() {
-        if (!confirm(`Reset the algorithm in profile "${profileName}"?`))
+        if (!confirm(`Reset the algorithm and statistics in profile "${profileName}"?`))
             return;
         const { timeSpentTotal = 0 } = JSON.parse(localStorage.getItem(`xikipedia-profile-${settings.profile}`) ?? '{}');
         localStorage.removeItem(`xikipedia-profile-${settings.profile}`);

--- a/index.html
+++ b/index.html
@@ -714,9 +714,11 @@
     }
 
     function resetAlgorithm() {
-        if (!confirm(`Reset the algorithm and statistics in profile "${profileName}"?`))
+        if (!confirm(`Reset the algorithm in profile "${profileName}"?`))
             return;
+        const { timeSpentTotal = 0 } = JSON.parse(localStorage.getItem(`xikipedia-profile-${settings.profile}`) ?? '{}');
         localStorage.removeItem(`xikipedia-profile-${settings.profile}`);
+        localStorage.setItem(`xikipedia-profile-${settings.profile}`, JSON.stringify({ timeSpentTotal }));
         loadProfile(settings.profile);
         document.location.reload();
     }


### PR DESCRIPTION
Previously ```function resetAlgorithm()``` would wipe the entire profile from local storage including time spent stat this pr fixes by preserving ```timeSpentTotal``` across algorithm resets