### PR TITLE
[BUGFIX - Issue #10] - Leaked MediaWiki table markup in article previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -813,8 +813,8 @@
         try {
             seenPosts.forEach(postId => {
                 const post = pagesArr.find(e=>e.id==postId);
-                post.seen = post.seen || 0;
-                post.seen += 1;
+                if (!post) return;
+                post.seen = (post.seen || 0) + 1;
             });
         } catch {}
         window.scrollTo(0, 0);
@@ -1072,6 +1072,16 @@
         document.querySelector(".posts").appendChild(postDiv);
     }
 
+    function cleanPostText(text) {
+        if (!text) return "";
+        // Drop leaked MediaWiki table markup: header rows ("! …") and any cell rows ("| …").
+        return text
+            .split("\n")
+            .filter(line => !/^\s*[!|]/.test(line))
+            .join("\n")
+            .trim();
+    }
+
     function getNextPost() {
         const potentialPosts = [...Array(10000)].map(e=>pagesArr[Math.floor(Math.random()*pagesArr.length)]).map(post => {
             const initialScore = (post.thumb ? 5 : 0) + (3**(post.seen??0)-1)*-50000;
@@ -1237,12 +1247,16 @@ async function* streamToAsyncIterable(stream) {
         let lastFrame = Date.now();
         while (smoldata.pages.length) {
             const e = smoldata.pages.pop();
-            const tempPage = {title:e[0],id:e[1],text:e[2],thumb:e[3],categories:e[4],links:e[5]};
             if (i % 1000 == 0 && Date.now() - lastFrame > 20) {
                 loadStatus(`${(i/wikiLen*100).toFixed(0)}%`);
                 await new Promise(e => requestAnimationFrame(e));
             }
             i++;
+            // Skip posts that are nothing but leaked table markup (e.g. table-only articles).
+            const cleanedText = cleanPostText(e[2]);
+            if (!cleanedText)
+                continue;
+            const tempPage = {title:e[0],id:e[1],text:cleanedText,thumb:e[3],categories:e[4],links:e[5]};
             //tempPage.allCategories = [...recursiveCategories(subCategories, [...tempPage.categories], 0), `p:${tempPage.id}`, ...tempPage.links.map(e=>`p:${e}`)];
             tempPage.allCategories = new Set(recursiveCategories(subCategories, [...tempPage.categories], 0));
             tempPage.allCategories.add(`p:${tempPage.id}`);

--- a/process_data.py
+++ b/process_data.py
@@ -23,7 +23,7 @@ def process_page(xml):
     text_toparse = text
     #text_toparse = re.sub('\\[\\[File:[^\\]]+\\]\\]\\n?', '', text_toparse)
     #text_toparse = re.sub('{{Infobox(?:[^{}]+(?:{{(?:[^{}]+(?:{{[^}]+}}|}))+}|}))+}', '', text_toparse, flags=re.MULTILINE)
-    text_toparse = "\n".join(x for x in text_toparse.split("\n") if not x.startswith("thumb|") if not x.upper().startswith("__NOTOC__") and (len(x) == 0 or not x[0] in "{}[]|&<>-*= ")).strip("\n")
+    text_toparse = "\n".join(x for x in text_toparse.split("\n") if not x.startswith("thumb|") if not x.upper().startswith("__NOTOC__") and (len(x) == 0 or not x[0] in "{}[]|!&<>-*= ")).strip("\n")
     text_toparse = re.sub(r'<ref[^>]*>.*?</ref>', '', text_toparse, flags=re.DOTALL)
     text_toparse = "\n".join(text_toparse.split("\n\n")[0].split("\n")[:8])
     #print(f"< {title} >")


### PR DESCRIPTION
**Disclaimer:** Used Claude Code + Opus 4.8 to make changes but I spent 30 minutes on this and refined the PR description it is not AI-Slop

## Problem

Table-only articles such as [UK railway stations – Q](https://en.wikipedia.org/wiki/UK_railway_stations_%E2%80%93_Q) render a garbled preview made of raw MediaWiki table-header markup, e.g.:

```
! align="left" valign="top" | Station Name
! colspan="2" |
! align="left" valign="top" | Postcode...
```
This is documented in #10.

Another case this arises is when MediaWiki tables are a part of the prose for an article like with Mr. Polar bear https://en.wikipedia.org/wiki/Grizzly%E2%80%93polar_bear_hybrid

## My opinionated solution
The `process_data.py` script already filters out non "prose" text so I added logic to the frontend to filter out anything that slipped through like wiki tables. 

If a article is completely a table (like for UK subway stations) it should just be filtered out completely

Also updated `process_data.py` so that future runs filter out the wikitable text direcly.

## Changes

- **`process_data.py`**: add `!` to the exclusion set so header rows are dropped like data rows. (Only affects future dump regenerations — the shipped `smoldata.json.br` is unchanged here.)
- **`index.html`**: add a render-time `cleanPostText()` safety-net that strips leaked `!`/`|` lines from the *already-shipped* data, and **skip posts entirely** when nothing remains after cleanup, so table-only articles never enter the feed. This fixes current users immediately without a heavyweight dump regen.
- **`index.html`**: make the `seen`-state restore null-safe, since a previously-seen id may no longer resolve to a post once table-only articles are skipped.

## Testing

Served locally with existing bundled wiki data and ran some tests in the console to confirm the changes work
<img width="976" height="358" alt="image" src="https://github.com/user-attachments/assets/c737fe1b-23fc-4260-ba13-0fef1efe5ce1" />

First, the UK subway station post is filtered out of the feed

Second, the partial match Grizzly bear article no longer contains != colspan garbage

Third, no other posts in the current feed array contain similar table header garbage that leaks through